### PR TITLE
If displaying method source fails for *_evaled methods, retry again.

### DIFF
--- a/test/test.rb
+++ b/test/test.rb
@@ -33,6 +33,10 @@ describe MethodSource do
     @lambda_comment = "# This is a comment for MyLambda\n"
     @lambda_source = "MyLambda = lambda { :lambda }\n"
     @proc_source = "MyProc = Proc.new { :proc }\n"
+    @hello_instance_evaled_source = "  def hello_\#{name}(*args)\n    send_mesg(:\#{name}, *args)\n  end\n"
+    @hello_instance_evaled_source_2 = "  def \#{name}_two()\n    if 44\n      45\n    end\n  end\n"
+    @hello_class_evaled_source = "  def hello_\#{name}(*args)\n    send_mesg(:\#{name}, *args)\n  end\n"
+    @hi_module_evaled_source = "  def hi_\#{name}\n    @var = \#{name}\n  end\n"
   end
 
   it 'should define methods on Method and UnboundMethod and Proc' do
@@ -58,11 +62,16 @@ describe MethodSource do
       $o.method(:hello).source.should == @hello_singleton_source
     end
 
-
     it 'should return a comment for method' do
       method(:hello).comment.should == @hello_comment
     end
 
+    it 'should return source for an *_evaled method' do
+      M.method(:hello_name).source.should == @hello_instance_evaled_source
+      M.method(:name_two).source.should == @hello_instance_evaled_source_2
+      M.instance_method(:hello_name).source.should == @hello_class_evaled_source
+      M.instance_method(:hi_name).source.should == @hi_module_evaled_source
+    end
 
     if !is_rbx?
       it 'should raise for C methods' do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -48,3 +48,47 @@ def comment_test5; end
 MyLambda = lambda { :lambda }
 MyProc = Proc.new { :proc }
 
+
+name = "name"
+
+M.instance_eval <<-METHOD, __FILE__, __LINE__ + 1
+  def hello_#{name}(*args)
+    send_mesg(:#{name}, *args)
+  end
+METHOD
+
+M.class_eval <<-METHOD, __FILE__, __LINE__ + 1
+  def hello_#{name}(*args)
+    send_mesg(:#{name}, *args)
+  end
+METHOD
+
+# module_eval to DRY code up
+#
+M.module_eval <<-METHOD, __FILE__, __LINE__ + 1
+
+  # module_eval is used here
+  #
+  def hi_#{name}
+    @var = #{name}
+  end
+METHOD
+
+# case where 2 methods are defined inside an _eval block
+#
+M.instance_eval <<EOF, __FILE__, __LINE__ + 1
+
+  def #{name}_one()
+    if 43
+      44
+    end
+  end
+
+
+  def #{name}_two()
+    if 44
+      45
+    end
+  end
+EOF
+


### PR DESCRIPTION
This time, check if inside an eval string. If it is, evaluate method body
after all occurences of #{} has been interpolated.
Only works if *_eval contains the arguments filename and lineno + 1. Without them,
UnboundMethod#source_location would not return the proper filename and lineno needed
to display the source.
