### PR TITLE
Add Ruby 2 to Travis CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rvm:
   - rbx-18mode
   - rbx-19mode
   - jruby
-
+  - 2.0.0
 notifications:
   irc: "irc.freenode.org#pry"
   recipients:

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
-source :rubygems
+source 'https://rubygems.org'
 gemspec


### PR DESCRIPTION
Added Ruby 2.0 to the Travis CI matrix
Replaced the 'source :rubygems' line to eliminate a warning.
