### PR TITLE
Removed file caching to allow live reloading of files

### DIFF
--- a/lib/method_source.rb
+++ b/lib/method_source.rb
@@ -49,8 +49,7 @@ module MethodSource
   # @return [Array<String>]  the contents of the file
   # @raise [SourceNotFoundError]
   def self.lines_for(file_name, name=nil)
-    @lines_for_file ||= {}
-    @lines_for_file[file_name] ||= File.readlines(file_name)
+    File.readlines(file_name)
   rescue Errno::ENOENT => e
     raise SourceNotFoundError, "Could not load source for #{name}: #{e.message}"
   end


### PR DESCRIPTION
This way if you reload a file that defines a proc or a method the source updates. It also prevents `SourceNotFound` errors in case the proc or method definition moves within the file.

