### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,28 @@
+bundler_args: "--verbose"
+before_install:
+  - gem update --system
+  - which bundle || gem install bundler
+  - gem update bundler
 rvm:
   - 1.8.7
   - 1.9.2
   - 1.9.3
   - ree
-  - rbx-18mode
-  - rbx-19mode
+  - rbx
   - jruby
+  - jruby-head
   - 2.0.0
   - 2.1
   - 2.2
   - 2.3
-  - 2.4.0
+  - 2.4.1
+  - ruby-head
+matrix:
+  allow_failures:
+    - rvm: ruby-head
+    - rvm: jruby-head
+    - rvm: rbx
+  fast_finish: true
 notifications:
   irc: "irc.freenode.org#pry"
   recipients:


### PR DESCRIPTION
I updated rubies to latest version.

I added `ruby-head` and `jruby-head` as `allow_failures` in `.travis.yml`.
I think this is useful.
Because we can prepare before next version Ruby 2.5 release.

We can see this kind of logic in `rails`, `rspec` and `cucumber` and etc.
https://github.com/rails/rails/blob/master/.travis.yml
https://github.com/rspec/rspec-core/blob/master/.travis.yml
https://github.com/cucumber/cucumber-ruby/blob/master/.travis.yml

Is it possible to add it?

Thanks.