### PR TITLE
Replace Bacon to RSpec 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+# To use rbx environment.
+dist: trusty
 bundler_args: "--verbose"
 before_install:
   - gem update --system
@@ -5,10 +7,9 @@ before_install:
   - gem update bundler
 rvm:
   - 1.8.7
-  - 1.9.2
   - 1.9.3
   - ree
-  - rbx
+  - rbx-3
   - jruby
   - jruby-head
   - 2.0.0
@@ -21,7 +22,7 @@ matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head
-    - rvm: rbx
+    - rvm: rbx-3
   fast_finish: true
 notifications:
   irc: "irc.freenode.org#pry"

--- a/Rakefile
+++ b/Rakefile
@@ -20,16 +20,17 @@ def apply_spec_defaults(s)
   s.description = s.summary
   s.require_path = 'lib'
 
-  s.add_development_dependency("bacon","~>1.1.0")
+  s.add_development_dependency("rspec","~>3.6")
   s.add_development_dependency("rake", "~>0.9")
   s.homepage = "http://banisterfiend.wordpress.com"
   s.has_rdoc = 'yard'
   s.files = `git ls-files`.split("\n")
-  s.test_files = `git ls-files -- test/*`.split("\n")
+  s.test_files = `git ls-files -- spec/*`.split("\n")
 end
 
-task :test do
-  sh "bacon -q #{direc}/test/test.rb #{direc}/test/test_code_helpers.rb"
+require "rspec/core/rake_task"
+RSpec::Core::RakeTask.new(:spec) do |t|
+  t.ruby_opts = %w[-w]
 end
 
 desc "reinstall gem"
@@ -39,7 +40,7 @@ task :reinstall => :gems do
 end
 
 desc "Set up and run tests"
-task :default => [:test]
+task :default => [:spec]
 
 desc "Build the gemspec file"
 task :gemspec => "ruby:gemspec"

--- a/method_source.gemspec
+++ b/method_source.gemspec
@@ -9,25 +9,25 @@ Gem::Specification.new do |s|
   s.date = "2012-10-17"
   s.description = "retrieve the sourcecode for a method"
   s.email = "jrmair@gmail.com"
-  s.files = [".gemtest", ".travis.yml", ".yardopts", "Gemfile", "LICENSE", "README.markdown", "Rakefile", "lib/method_source.rb", "lib/method_source/code_helpers.rb", "lib/method_source/source_location.rb", "lib/method_source/version.rb", "method_source.gemspec", "test/test.rb", "test/test_code_helpers.rb", "test/test_helper.rb"]
+  s.files = [".gemtest", ".travis.yml", ".yardopts", "Gemfile", "LICENSE", "README.markdown", "Rakefile", "lib/method_source.rb", "lib/method_source/code_helpers.rb", "lib/method_source/source_location.rb", "lib/method_source/version.rb", "method_source.gemspec", "spec/method_source/code_helpers_spec.rb", "spec/method_source_spec.rb", "spec/spec_helper.rb"]
   s.homepage = "http://banisterfiend.wordpress.com"
   s.require_paths = ["lib"]
   s.rubygems_version = "1.8.23"
   s.summary = "retrieve the sourcecode for a method"
-  s.test_files = ["test/test.rb", "test/test_code_helpers.rb", "test/test_helper.rb"]
+  s.test_files = ["spec/method_source/code_helpers_spec.rb", "spec/method_source_spec.rb", "spec/spec_helper.rb"]
 
   if s.respond_to? :specification_version then
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_development_dependency(%q<bacon>, ["~> 1.1.0"])
+      s.add_development_dependency(%q<rspec>, ["~> 3.6"])
       s.add_development_dependency(%q<rake>, ["~> 0.9"])
     else
-      s.add_dependency(%q<bacon>, ["~> 1.1.0"])
+      s.add_dependency(%q<rspec>, ["~> 3.6"])
       s.add_dependency(%q<rake>, ["~> 0.9"])
     end
   else
-    s.add_dependency(%q<bacon>, ["~> 1.1.0"])
+    s.add_dependency(%q<rspec>, ["~> 3.6"])
     s.add_dependency(%q<rake>, ["~> 0.9"])
   end
 end

--- a/spec/method_source/code_helpers_spec.rb
+++ b/spec/method_source/code_helpers_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 describe MethodSource::CodeHelpers do
   before do
     @tester = Object.new.extend(MethodSource::CodeHelpers)
@@ -17,9 +19,9 @@ describe MethodSource::CodeHelpers do
   ].each do |lines|
     it "should not raise an error on broken lines: #{lines.join("\\n")}" do
       1.upto(lines.size - 1) do |i|
-        @tester.complete_expression?(lines[0...i].join("\n") + "\n").should == false
+        expect(@tester.complete_expression?(lines[0...i].join("\n") + "\n")).to be_falsy
       end
-      @tester.complete_expression?(lines.join("\n")).should == true
+      expect(@tester.complete_expression?(lines.join("\n"))).to be_truthy
     end
   end
 
@@ -33,9 +35,9 @@ describe MethodSource::CodeHelpers do
     ["o = Object.new.tap{ def o.render;","'MEH'", "}"] # in this case the syntax error is "expecting keyword_end".
   ]).compact.each do |foo|
     it "should raise an error on invalid syntax like #{foo.inspect}" do
-      lambda{
+      expect {
         @tester.complete_expression?(foo.join("\n"))
-      }.should.raise(SyntaxError)
+      }.to raise_error(SyntaxError)
     end
   end
 end

--- a/spec/method_source_spec.rb
+++ b/spec/method_source_spec.rb
@@ -1,26 +1,25 @@
-direc = File.expand_path(File.dirname(__FILE__))
-
-require 'rubygems'
-require 'bacon'
-require "#{direc}/../lib/method_source"
-require "#{direc}/test_helper"
+require 'spec_helper'
 
 describe MethodSource do
 
   describe "source_location (testing 1.8 implementation)" do
     it 'should return correct source_location for a method' do
-      method(:hello).source_location.first.should =~ /test_helper/
+      expect(method(:hello).source_location.first).to match(/spec_helper/)
     end
 
     it 'should not raise for immediate instance methods' do
       [Symbol, Integer, TrueClass, FalseClass, NilClass].each do |immediate_class|
-        lambda { immediate_class.instance_method(:to_s).source_location }.should.not.raise
+        expect do
+          immediate_class.instance_method(:to_s).source_location
+        end.not_to raise_error
       end
     end
 
     it 'should not raise for immediate methods' do
       [:a, 1, true, false, nil].each do |immediate|
-        lambda { immediate.method(:to_s).source_location }.should.not.raise
+        expect do
+          immediate.method(:to_s).source_location
+        end.not_to raise_error
       end
     end
   end
@@ -40,49 +39,55 @@ describe MethodSource do
   end
 
   it 'should define methods on Method and UnboundMethod and Proc' do
-    Method.method_defined?(:source).should == true
-    UnboundMethod.method_defined?(:source).should == true
-    Proc.method_defined?(:source).should == true
+    expect(Method.method_defined?(:source)).to be_truthy
+    expect(UnboundMethod.method_defined?(:source)).to be_truthy
+    expect(Proc.method_defined?(:source)).to be_truthy
   end
 
   describe "Methods" do
     it 'should return source for method' do
-      method(:hello).source.should == @hello_source
+      expect(method(:hello).source).to eq(@hello_source)
     end
 
     it 'should return source for a method defined in a module' do
-      M.instance_method(:hello).source.should == @hello_module_source
+      expect(M.instance_method(:hello).source).to eq(@hello_module_source)
     end
 
     it 'should return source for a singleton method as an instance method' do
-      class << $o; self; end.instance_method(:hello).source.should == @hello_singleton_source
+      expect(class << $o
+        self
+      end.instance_method(:hello).source).to eq(@hello_singleton_source)
     end
 
     it 'should return source for a singleton method' do
-      $o.method(:hello).source.should == @hello_singleton_source
+      expect($o.method(:hello).source).to eq(@hello_singleton_source)
     end
 
     it 'should return a comment for method' do
-      method(:hello).comment.should == @hello_comment
+      expect(method(:hello).comment).to eq(@hello_comment)
     end
 
     # These tests fail because of http://jira.codehaus.org/browse/JRUBY-4576
     unless defined?(RUBY_ENGINE) && RUBY_ENGINE == "jruby"
       it 'should return source for an *_evaled method' do
-        M.method(:hello_name).source.should == @hello_instance_evaled_source
-        M.method(:name_two).source.should == @hello_instance_evaled_source_2
-        M.instance_method(:hello_name).source.should == @hello_class_evaled_source
-        M.instance_method(:hi_name).source.should == @hi_module_evaled_source
+        expect(M.method(:hello_name).source).to eq(@hello_instance_evaled_source)
+        expect(M.method(:name_two).source).to eq(@hello_instance_evaled_source_2)
+        expect(M.instance_method(:hello_name).source).to eq(@hello_class_evaled_source)
+        expect(M.instance_method(:hi_name).source).to eq(@hi_module_evaled_source)
       end
     end
 
     it "should raise error for evaled methods that do not pass __FILE__ and __LINE__ + 1 as its arguments" do
-      lambda { M.instance_method(:name_three).source }.should.raise MethodSource::SourceNotFoundError
+      expect do
+        M.instance_method(:name_three).source
+      end.to raise_error(MethodSource::SourceNotFoundError)
     end
 
     if !is_rbx?
       it 'should raise for C methods' do
-        lambda { method(:puts).source }.should.raise MethodSource::SourceNotFoundError
+        expect do
+          method(:puts).source
+        end.to raise_error(MethodSource::SourceNotFoundError)
       end
     end
   end
@@ -90,19 +95,19 @@ describe MethodSource do
   # if RUBY_VERSION =~ /1.9/ || is_rbx?
   describe "Lambdas and Procs" do
     it 'should return source for proc' do
-      MyProc.source.should == @proc_source
+      expect(MyProc.source).to eq(@proc_source)
     end
 
     it 'should return an empty string if there is no comment' do
-      MyProc.comment.should == ''
+      expect(MyProc.comment).to eq('')
     end
 
     it 'should return source for lambda' do
-      MyLambda.source.should == @lambda_source
+      expect(MyLambda.source).to eq(@lambda_source)
     end
 
     it 'should return comment for lambda' do
-      MyLambda.comment.should == @lambda_comment
+      expect(MyLambda.comment).to eq(@lambda_comment)
     end
   end
   # end
@@ -116,23 +121,23 @@ describe MethodSource do
     end
 
     it "should correctly extract multi-line comments" do
-      method(:comment_test1).comment.should == @comment1
+      expect(method(:comment_test1).comment).to eq(@comment1)
     end
 
     it "should correctly strip leading whitespace before comments" do
-      method(:comment_test2).comment.should == @comment2
+      expect(method(:comment_test2).comment).to eq(@comment2)
     end
 
     it "should keep empty comment lines" do
-      method(:comment_test3).comment.should == @comment3
+      expect(method(:comment_test3).comment).to eq(@comment3)
     end
 
     it "should ignore blank lines between comments" do
-      method(:comment_test4).comment.should == @comment4
+      expect(method(:comment_test4).comment).to eq(@comment4)
     end
 
     it "should align all comments to same indent level" do
-      method(:comment_test5).comment.should == @comment5
+      expect(method(:comment_test5).comment).to eq(@comment5)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,6 @@
+require 'method_source'
+require 'rspec'
+
 def is_rbx?
   defined?(RUBY_ENGINE) && RUBY_ENGINE =~ /rbx/
 end


### PR DESCRIPTION
This fixes https://github.com/banister/method_source/issues/43
Because Bacon stopped the development.

Bacon is kind of light weight testing framework.
So, changing to RSpec was easier than minitest.

I changed testing directory from `test` to `spec` because `spec` is default directory for RSpec.
I modified `method_source.gemspec`, as I changed test file name.

But I want to suggest that you will auto-generate `gemspec` file from `Rakefile` by `rake gemspec` by yourself. I did not do it this time by myself. Because the gemsepc file has many differences between before and after.

Or you can consider static gemspec file such as
Ref.
https://github.com/rack-test/rack-test/blob/master/rack-test.gemspec
https://github.com/rack-test/rack-test/pull/181 Maybe good reference. Yesterday's my work :)
https://github.com/rspec/rspec-core/blob/master/rspec-core.gemspec
https://github.com/rails/rails/blob/master/activesupport/activesupport.gemspec

```
$ ruby -v
ruby 2.4.1p111 (2017-03-22 revision 58053) [x86_64-linux]

$ bundle exec rake -T
rake clean                 # Remove any temporary products.
rake clobber               # Remove any generated file.
rake default               # Set up and run tests
rake gems                  # build all platform gems at once
rake gemspec               # Build the gemspec file
rake pushgems              # build and push latest gems
rake reinstall             # reinstall gem
rake rmgems                # remove all platform gems
rake ruby:clobber_package  # Remove package products
rake ruby:gem              # Build the gem file method_source-0.8.2.gem
rake ruby:gemspec          # Generate gemspec file
rake ruby:package          # Build all the packages
rake ruby:repackage        # Force a rebuild of the package files
rake spec                  # Run RSpec code examples

$ bundle exec rake
/usr/local/ruby-2.4.1/bin/ruby -w -I/home/jaruga/git/method_source/vendor/bundle/ruby/2.4.0/gems/rspec-core-3.6.0/lib:/home/jaruga/git/method_source/vendor/bundle/ruby/2.4.0/gems/rspec-support-3.6.0/lib /home/jaruga/git/method_source/vendor/bundle/ruby/2.4.0/gems/rspec-core-3.6.0/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
/home/jaruga/git/method_source/spec/spec_helper.rb:85: warning: literal in condition
/home/jaruga/git/method_source/spec/spec_helper.rb:92: warning: literal in condition
.................................

Finished in 0.01286 seconds (files took 0.0775 seconds to load)
33 examples, 0 failures
```


