### PR TITLE
Improve frozen-string-literals compatibility.

### DIFF
--- a/lib/method_source/code_helpers.rb
+++ b/lib/method_source/code_helpers.rb
@@ -90,7 +90,7 @@ module MethodSource
     # @return [String]  a valid ruby expression
     # @raise [SyntaxError]
     def extract_first_expression(lines, consume=0, &block)
-      code = consume.zero? ? "" : lines.slice!(0..(consume - 1)).join
+      code = consume.zero? ? "".dup : lines.slice!(0..(consume - 1)).join
 
       lines.each do |v|
         code << v
@@ -104,7 +104,7 @@ module MethodSource
     # @param [Array<String>]  lines
     # @return [String]
     def extract_last_comment(lines)
-      buffer = ""
+      buffer = "".dup
 
       lines.each do |line|
         # Add any line that is a valid ruby comment,
@@ -112,7 +112,7 @@ module MethodSource
         if (line =~ /^\s*#/) || (line =~ /^\s*$/)
           buffer << line.lstrip
         else
-          buffer.replace("")
+          buffer.replace("".dup)
         end
       end
 


### PR DESCRIPTION
A few simple changes to allow this gem to be used when `RUBYOPT="--enable-frozen-string-literal"` is set in MRI 2.4+.

However, it's worth noting that Bacon isn't frozen-string-literal friendly, so the test suite can't be run with this flag. I've addressed this [in a PR](https://github.com/chneukirchen/bacon/pull/33), but there hasn't been a gem release of Bacon for quite some time (as noted in #45) - so it's worth considering changing to a git repo reference in the Gemfile? This way, you'll be able to add the RUBYOPT flag for 2.4+ versions of Ruby in your test suite and avoid regression errors :)