### PR TITLE
method_source: fix broken Procs on JRuby 9.2.0.0

### DIFF
--- a/spec/method_source_spec.rb
+++ b/spec/method_source_spec.rb
@@ -31,7 +31,7 @@ describe MethodSource do
     @hello_comment = "# A comment for hello\n# It spans two lines and is indented by 2 spaces\n"
     @lambda_comment = "# This is a comment for MyLambda\n"
     @lambda_source = "MyLambda = lambda { :lambda }\n"
-    @proc_source = "MyProc = Proc.new { :proc }\n"
+    @proc_source = "MyProc = Proc.new do\n\n\nend\n"
     @hello_instance_evaled_source = "  def hello_\#{name}(*args)\n    send_mesg(:\#{name}, *args)\n  end\n"
     @hello_instance_evaled_source_2 = "  def \#{name}_two()\n    if 44\n      45\n    end\n  end\n"
     @hello_class_evaled_source = "  def hello_\#{name}(*args)\n    send_mesg(:\#{name}, *args)\n  end\n"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -49,8 +49,10 @@ def comment_test5; end
 
 # This is a comment for MyLambda
 MyLambda = lambda { :lambda }
-MyProc = Proc.new { :proc }
+MyProc = Proc.new do
 
+
+end
 
 name = "name"
 
@@ -98,4 +100,3 @@ EOF
 # class_eval without filename and lineno + 1 parameter
 
 M.class_eval "def #{name}_three; @tempfile.#{name}; end"
-


### PR DESCRIPTION
Fixes https://github.com/pry/pry/issues/1804
(JRuby 9.2.0.0 breaks `source_location` and therefore our test suite)

JRuby 9.2.0.0 fails to fetch source code for procs because of the bug:
https://github.com/jruby/jruby/pull/5262

The problem is that source_location is reported at the end of the proc, instead
of the beginning.

The way I fix it is rather dumb (rewinding back and checking if it's complete
expression) but it's isolated only to 9.2.0.0 and likely won't be needed when
another JRuby is released. However, so far it's the latest release.