### PR TITLE
Revert "method_source: fix broken Procs on JRuby 9.2.0.0"

### DIFF
--- a/lib/method_source/code_helpers.rb
+++ b/lib/method_source/code_helpers.rb
@@ -1,9 +1,6 @@
 module MethodSource
 
   module CodeHelpers
-    # @return [Boolean]
-    JRUBY_9200 = (defined?(JRUBY_VERSION) || false) && JRUBY_VERSION == '9.2.0.0'
-
     # Retrieve the first expression starting on the given line of the given file.
     #
     # This is useful to get module or method source code.
@@ -32,26 +29,6 @@ module MethodSource
 
       extract_first_expression(relevant_lines, options[:consume])
     rescue SyntaxError => e
-      # JRuby 9.2.0.0 breaks #source_location for Procs (it reports line number
-      # as the last line of the Proc). This raises SyntaxError.
-      # See https://github.com/pry/pry/issues/1804 for details.
-      #
-      # To fix this, this hack rewinds source location one step at a time and
-      # tries to see if the new location is a complete expression.
-      #
-      # TODO: delete this once latest JRuby version is bumped.
-      # See https://github.com/banister/method_source/issues/52
-      if JRUBY_9200 && line_number > 0
-        loop do
-          line_number -= 1
-
-          # Skip empty lines since they are not real expressions.
-          break unless lines[line_number - 1] == "\n"
-        end
-
-        retry
-      end
-
       raise if options[:strict]
 
       begin

--- a/spec/method_source_spec.rb
+++ b/spec/method_source_spec.rb
@@ -31,7 +31,7 @@ describe MethodSource do
     @hello_comment = "# A comment for hello\n# It spans two lines and is indented by 2 spaces\n"
     @lambda_comment = "# This is a comment for MyLambda\n"
     @lambda_source = "MyLambda = lambda { :lambda }\n"
-    @proc_source = "MyProc = Proc.new do\n\n\nend\n"
+    @proc_source = "MyProc = Proc.new { :proc }\n"
     @hello_instance_evaled_source = "  def hello_\#{name}(*args)\n    send_mesg(:\#{name}, *args)\n  end\n"
     @hello_instance_evaled_source_2 = "  def \#{name}_two()\n    if 44\n      45\n    end\n  end\n"
     @hello_class_evaled_source = "  def hello_\#{name}(*args)\n    send_mesg(:\#{name}, *args)\n  end\n"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -49,10 +49,8 @@ def comment_test5; end
 
 # This is a comment for MyLambda
 MyLambda = lambda { :lambda }
-MyProc = Proc.new do
+MyProc = Proc.new { :proc }
 
-
-end
 
 name = "name"
 
@@ -100,3 +98,4 @@ EOF
 # class_eval without filename and lineno + 1 parameter
 
 M.class_eval "def #{name}_three; @tempfile.#{name}; end"
+


### PR DESCRIPTION
Fixes #52 (Revert the JRuby 9.2.0.0 source_location hack once the newest version
is out)

This reverts commit 20fb1efde4530c78f7627d8b5b4e0b3f43cf821d.