### PR TITLE
Handle new message for unterminated lists on MRI 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ rvm:
   - "2.4"
   - "2.5"
   - "2.6"
+  - "2.7"
   - ruby-head
 matrix:
   allow_failures:

--- a/lib/method_source/code_helpers.rb
+++ b/lib/method_source/code_helpers.rb
@@ -125,7 +125,7 @@ module MethodSource
       GENERIC_REGEXPS = [
         /unexpected (\$end|end-of-file|end-of-input|END_OF_FILE)/, # mri, jruby, ruby-2.0, ironruby
         /embedded document meets end of file/, # =begin
-        /unterminated (quoted string|string|regexp) meets end of file/, # "quoted string" is ironruby
+        /unterminated (quoted string|string|regexp|list) meets end of file/, # "quoted string" is ironruby
         /can't find string ".*" anywhere before EOF/, # rbx and jruby
         /missing 'end' for/, /expecting kWHEN/ # rbx
       ]


### PR DESCRIPTION
Ref: https://github.com/pry/pry/pull/2087

Pry test suite breaks on MRI 2.7 previews because of this.

The error message for `issue = %W/` changed, before:

```
(eval):2: syntax error, unexpected tSTRING_END, expecting tSTRING_CONTENT or tSTRING_DBEG or tSTRING_DVAR or ' '
```

After:

```
((eval):2: unterminated list meets end of file)
```

@kyrylo @banister 