### PR TITLE
Fix CI builds and add newer ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,13 @@ rvm:
   - rbx-3
   - jruby
   - jruby-head
-  - 2.0.0
-  - 2.1
-  - 2.2
-  - 2.3
-  - 2.4.2
+  - "2.0"
+  - "2.1"
+  - "2.2"
+  - "2.3"
+  - "2.4"
+  - "2.5"
+  - "2.6"
   - ruby-head
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 dist: trusty
 bundler_args: "--verbose"
 before_install:
-  - gem update --system
   - which bundle || gem install bundler
   - gem update bundler
 rvm:

--- a/spec/method_source_spec.rb
+++ b/spec/method_source_spec.rb
@@ -33,7 +33,7 @@ describe MethodSource do
     @lambda_source = "MyLambda = lambda { :lambda }\n"
     @proc_source = "MyProc = Proc.new { :proc }\n"
     @hello_instance_evaled_source = "  def hello_\#{name}(*args)\n    send_mesg(:\#{name}, *args)\n  end\n"
-    @hello_instance_evaled_source_2 = "  def \#{name}_two()\n    if 44\n      45\n    end\n  end\n"
+    @hello_instance_evaled_source_2 = "  def \#{name}_two()\n    if 40 + 4\n      45\n    end\n  end\n"
     @hello_class_evaled_source = "  def hello_\#{name}(*args)\n    send_mesg(:\#{name}, *args)\n  end\n"
     @hi_module_evaled_source = "  def hi_\#{name}\n    @var = \#{name}\n  end\n"
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -82,14 +82,14 @@ METHOD
 M.instance_eval <<EOF, __FILE__, __LINE__ + 1
 
   def #{name}_one()
-    if 43
+    if 40 + 3
       44
     end
   end
 
 
   def #{name}_two()
-    if 44
+    if 40 + 4
       45
     end
   end


### PR DESCRIPTION
`gem update --system` made CI break because recent versions of Rubygems broke compatibility with EOL rubies.

Simply not upgrading rubygems fixes CI and is a tiny bit faster.

I also added MRI 2.5 and 2.6.

And finally I fixed a Ruby warning:

```
/home/travis/build/banister/method_source/spec/spec_helper.rb:85: warning: literal in condition
/home/travis/build/banister/method_source/spec/spec_helper.rb:92: warning: literal in condition
```