### PR TITLE
More closely match MIT License text verbatim

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,4 @@
-License
--------
-
-(The MIT License) 
+MIT License
 
 Copyright (c) 2011 John Mair (banisterfiend)
 


### PR DESCRIPTION
Tweak the license such that tooling (in particular, [`licensee`](https://github.com/licensee/licensee)) recognizes the LICENSE file as MIT.

Before:

```
$ /usr/local/share/gem/bin/licensee 
License:        NOASSERTION
Matched files:  LICENSE, README.markdown, method_source.gemspec
LICENSE:
  Content hash:  bfd1a6d003c3210704bb2025ee95bfc059adcd4d
  License:       NOASSERTION
```

After:
```
$ /usr/local/share/gem/bin/licensee 
License:        MIT
Matched files:  LICENSE, README.markdown, method_source.gemspec
LICENSE:
  Content hash:  d64f3bb4282a97b37454b5bb96a8a264a3363dc3
  Attribution:   Copyright (c) 2011 John Mair (banisterfiend)
  Confidence:    100.00%
  Matcher:       Licensee::Matchers::Exact
  License:       MIT
```