### PR TITLE
Add changelog to gemspec

### DIFF
--- a/method_source.gemspec
+++ b/method_source.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
   s.email = "jrmair@gmail.com".freeze
   s.files = ["CHANGELOG.md".freeze, ".gemtest".freeze, ".travis.yml".freeze, ".yardopts".freeze, "Gemfile".freeze, "LICENSE".freeze, "README.markdown".freeze, "Rakefile".freeze, "lib/method_source.rb".freeze, "lib/method_source/code_helpers.rb".freeze, "lib/method_source/source_location.rb".freeze, "lib/method_source/version.rb".freeze, "method_source.gemspec".freeze, "spec/method_source/code_helpers_spec.rb".freeze, "spec/method_source_spec.rb".freeze, "spec/spec_helper.rb".freeze]
   s.homepage = "http://banisterfiend.wordpress.com".freeze
+  s.metadata["changelog_uri"] = "https://github.com/banister/method_source/blob/master/CHANGELOG.md".freeze
   s.licenses = ["MIT".freeze]
   s.summary = "retrieve the sourcecode for a method".freeze
   s.test_files = ["spec/method_source/code_helpers_spec.rb".freeze, "spec/method_source_spec.rb".freeze, "spec/spec_helper.rb".freeze]


### PR DESCRIPTION
For a nice “Changelog” link in the https://rubygems.org/gems/method_source sidebar.