### PR TITLE
Allow fetching class/module comments

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -50,6 +50,14 @@ Example: display method comments
     # Merges the elements of the given enumerable object to the set and
     # returns self.
 
+Example: display module/class comments
+--------------------------------------
+
+    MethodSource::MethodExtensions.method(:included).module_comment
+    # =>
+    # This module is to be included by `Method` and `UnboundMethod` and
+    # provides the `#source` functionality
+
 Limitations:
 ------------
 

--- a/lib/method_source.rb
+++ b/lib/method_source.rb
@@ -121,6 +121,37 @@ module MethodSource
     def comment
       MethodSource.comment_helper(source_location, defined?(name) ? name : inspect)
     end
+
+    # Return the comments associated with the method class/module.
+    # @return [String] The method's comments as a string
+    # @raise SourceNotFoundException
+    #
+    # @example
+    #  MethodSource::MethodExtensions.method(:included).module_comment
+    #  =>
+    #     # This module is to be included by `Method` and `UnboundMethod` and
+    #     # provides the `#source` functionality
+    def class_comment
+      if self.respond_to?(:receiver)
+        class_inst_or_module =  self.receiver
+      elsif self.respond_to?(:owner)
+        class_inst_or_module = self.owner
+      else
+        return comment
+      end
+
+      if class_inst_or_module.respond_to?(:name)
+        const_name = class_inst_or_module.name
+      else
+        const_name = class_inst_or_module.class.name
+        class_inst_or_module = class_inst_or_module.class
+      end
+
+      location = class_inst_or_module.const_source_location(const_name)
+
+      MethodSource.comment_helper(location, defined?(name) ? name : inspect)
+    end
+    alias module_comment class_comment
   end
 end
 

--- a/spec/method_source_spec.rb
+++ b/spec/method_source_spec.rb
@@ -30,6 +30,8 @@ describe MethodSource do
     @hello_source = "def hello; :hello; end\n"
     @hello_comment = "# A comment for hello\n# It spans two lines and is indented by 2 spaces\n"
     @lambda_comment = "# This is a comment for MyLambda\n"
+    @module_comment = "# This is a comment for module\n"
+    @class_comment = "# This is a comment for class\n"
     @lambda_source = "MyLambda = lambda { :lambda }\n"
     @proc_source = "MyProc = Proc.new { :proc }\n"
     @hello_instance_evaled_source = "  def hello_\#{name}(*args)\n    send_mesg(:\#{name}, *args)\n  end\n"
@@ -108,6 +110,18 @@ describe MethodSource do
 
     it 'should return comment for lambda' do
       expect(MyLambda.comment).to eq(@lambda_comment)
+    end
+
+    it 'should return comment for module' do
+      expect(M.instance_method(:hello).module_comment).to eq(@module_comment)
+    end
+
+    it 'should return comment for class' do
+      expect(C.method(:hello).class_comment).to eq(@class_comment)
+    end
+
+    it 'should return comment for class instance' do
+      expect(C.new.method(:hello).class_comment).to eq(@class_comment)
     end
   end
   # end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,8 +10,14 @@ def jruby?
 end
 
 
+# This is a comment for module
 module M
   def hello; :hello_module; end
+end
+
+# This is a comment for class
+class C
+  include M
 end
 
 $o = Object.new


### PR DESCRIPTION
Added a couple of extra lines of code to allow fetching class/module comments.

The API might be improved, but I really didn't want to extend module/class builtins, and wanted to limit the changeset to the gist of it.

Would be happy to get some feedback and if it's found useful. Thank you for the great little tool! :heart: 