### PR TITLE
Add MethodSource.clear_cache

### DIFF
--- a/lib/method_source.rb
+++ b/lib/method_source.rb
@@ -55,6 +55,11 @@ module MethodSource
     raise SourceNotFoundError, "Could not load source for #{name}: #{e.message}"
   end
 
+  # Clear cache.
+  def self.clear_cache
+    @lines_for_file = {}
+  end
+
   # @deprecated — use MethodSource::CodeHelpers#complete_expression?
   def self.valid_expression?(str)
     complete_expression?(str)


### PR DESCRIPTION
We often need to clear cache.

For example, in web application development, when we changed source code, we would like the change applied to the app server without reboot.

In the case of a Rails application, this requires the following configuration:

```ruby
Rails.application.configure do
  config.to_prepare do
    MethodSource.instance_variable_set(:@lines_for_file, {})
  end
end
```

It seems so ugly, isn't it? So I feel we need to add `MethodSource.clear_cache` interface.

```diff
  Rails.application.configure do
    config.to_prepare do
-     MethodSource.instance_variable_set(:@lines_for_file, {})
+     MethodSource.clear_cache
    end
  end
```