### PR TITLE
Make `extract_last_comment` 65x faster

### DIFF
--- a/lib/method_source/code_helpers.rb
+++ b/lib/method_source/code_helpers.rb
@@ -103,17 +103,42 @@ module MethodSource
     #
     # @param [Array<String>]  lines
     # @return [String]
-    def extract_last_comment(lines)
+    def extract_last_comment_core(lines)
       buffer = ""
+      found_at_least_one_comment = false
 
       lines.each do |line|
         # Add any line that is a valid ruby comment,
         # but clear as soon as we hit a non comment line.
+        if (line =~ /^\s*#/)
+          found_at_least_one_comment = true
+        end
+
         if (line =~ /^\s*#/) || (line =~ /^\s*$/)
           buffer << line.lstrip
         else
           buffer.replace("")
         end
+      end
+
+      return [ buffer, found_at_least_one_comment ]
+    end
+
+    def extract_last_comment(lines)
+      found_at_least_one_comment = false
+      lines_threshold = 100
+
+      if lines.size > lines_threshold
+        # if the last comment is found over fewer lines then don't
+        # need to go over all lines
+        index_start = (lines.size-lines_threshold)
+        index_start = 0 if index_start < 0
+        index_stop = (lines.size-1)
+        buffer, found_at_least_one_comment = extract_last_comment_core(lines[index_start..index_stop])
+      end
+
+      if not found_at_least_one_comment
+        buffer, found_at_least_one_comment = extract_last_comment_core(lines)
       end
 
       buffer

--- a/lib/method_source/code_helpers.rb
+++ b/lib/method_source/code_helpers.rb
@@ -1,9 +1,6 @@
 module MethodSource
 
   module CodeHelpers
-
-    @@EXTRACT_LAST_COMMENT_THRESHOLD = 100
-
     # Retrieve the first expression starting on the given line of the given file.
     #
     # This is useful to get module or method source code.

--- a/lib/method_source/code_helpers.rb
+++ b/lib/method_source/code_helpers.rb
@@ -106,52 +106,20 @@ module MethodSource
     #
     # @param [Array<String>]  lines
     # @return [String]
-    def extract_last_comment_core(lines)
-      buffer = ""
-      found_at_least_one_comment = false
-
-      lines.each do |line|
-        # Add any line that is a valid ruby comment,
-        # but clear as soon as we hit a non comment line.
-        starts_with_comment = (line =~ /^\s*#/)
-        if starts_with_comment
-          found_at_least_one_comment = true
-        end
-
-        if starts_with_comment || (line =~ /^\s*$/)
-          # this works
-          buffer += line.lstrip
-          # this breaks with Ruby 2.7.2p137: execution doesn't
-          # continue past it and no exception is raised
-          # buffer << line.lstrip
-        else
-          # this often breaks
-          # buffer.replace("")
-          # this works
-          buffer = ""
-        end
-      end
-
-      return [ buffer, found_at_least_one_comment ]
-    end
-
     def extract_last_comment(lines)
-      found_at_least_one_comment = false
+      buffer = []
 
-      if lines.size > @@EXTRACT_LAST_COMMENT_THRESHOLD
-        # if the last comment is found over fewer lines then don't
-        # need to go over all lines
-        index_start = (lines.size - @@EXTRACT_LAST_COMMENT_THRESHOLD)
-        index_start = 0 if index_start < 0
-        index_stop = (lines.size-1)
-        buffer, found_at_least_one_comment = extract_last_comment_core(lines[index_start..index_stop])
+      lines.reverse.each do |line|
+        # Add any line that is a valid ruby comment, and stop as
+        # soon as we hit a non comment line.
+        if (line =~ /^\s*#/) || (line =~ /^\s*$/)
+          buffer.append(line.lstrip)
+        else
+          break
+        end
       end
 
-      if not found_at_least_one_comment
-        buffer, found_at_least_one_comment = extract_last_comment_core(lines)
-      end
-
-      buffer
+      buffer.reverse.join()
     end
 
     # An exception matcher that matches only subsets of SyntaxErrors that can be

--- a/lib/method_source/code_helpers.rb
+++ b/lib/method_source/code_helpers.rb
@@ -110,11 +110,12 @@ module MethodSource
       lines.each do |line|
         # Add any line that is a valid ruby comment,
         # but clear as soon as we hit a non comment line.
-        if (line =~ /^\s*#/)
+        starts_with_comment = (line =~ /^\s*#/)
+        if starts_with_comment
           found_at_least_one_comment = true
         end
 
-        if (line =~ /^\s*#/) || (line =~ /^\s*$/)
+        if starts_with_comment || (line =~ /^\s*$/)
           buffer << line.lstrip
         else
           buffer.replace("")

--- a/lib/method_source/code_helpers.rb
+++ b/lib/method_source/code_helpers.rb
@@ -1,6 +1,9 @@
 module MethodSource
 
   module CodeHelpers
+
+    @@EXTRACT_LAST_COMMENT_THRESHOLD = 100
+
     # Retrieve the first expression starting on the given line of the given file.
     #
     # This is useful to get module or method source code.
@@ -134,12 +137,11 @@ module MethodSource
 
     def extract_last_comment(lines)
       found_at_least_one_comment = false
-      lines_threshold = 100
 
-      if lines.size > lines_threshold
+      if lines.size > @@EXTRACT_LAST_COMMENT_THRESHOLD
         # if the last comment is found over fewer lines then don't
         # need to go over all lines
-        index_start = (lines.size-lines_threshold)
+        index_start = (lines.size - @@EXTRACT_LAST_COMMENT_THRESHOLD)
         index_start = 0 if index_start < 0
         index_stop = (lines.size-1)
         buffer, found_at_least_one_comment = extract_last_comment_core(lines[index_start..index_stop])

--- a/lib/method_source/code_helpers.rb
+++ b/lib/method_source/code_helpers.rb
@@ -116,9 +116,16 @@ module MethodSource
         end
 
         if starts_with_comment || (line =~ /^\s*$/)
-          buffer << line.lstrip
+          # this works
+          buffer += line.lstrip
+          # this breaks with Ruby 2.7.2p137: execution doesn't
+          # continue past it and no exception is raised
+          # buffer << line.lstrip
         else
-          buffer.replace("")
+          # this often breaks
+          # buffer.replace("")
+          # this works
+          buffer = ""
         end
       end
 

--- a/lib/method_source/code_helpers.rb
+++ b/lib/method_source/code_helpers.rb
@@ -106,7 +106,7 @@ module MethodSource
     def extract_last_comment(lines)
       buffer = []
 
-      lines.reverse.each do |line|
+      lines.reverse_each do |line|
         # Add any line that is a valid ruby comment, and stop as
         # soon as we hit a non comment line.
         if (line =~ /^\s*#/) || (line =~ /^\s*$/)


### PR DESCRIPTION
In `extract_last_comment` don't go over all lines of the file if the last comment is in the last 100 lines.

When used with a benchmark that called `extract_last_comment` 56411 times:
- <del>this improved performance by 3.42x (reduced execution time from `20.15s` to `5.89s`)</del>
- this improved performance by 65.4x (reduced execution time from `20.15s` to `0.31s`) when parsing comments backwards.
- <del>when the median number of lines in the opened files was 264 lines.</del>

<del>I tried to tune this with a different threshold, like 50-80 lines or 150-500 lines, and ~100 lines worked well for the benchmark used.</del>