### PR TITLE
[jruby] avoid Thread#to_java internals

### DIFF
--- a/lib/method_source/source_location.rb
+++ b/lib/method_source/source_location.rb
@@ -13,15 +13,8 @@ module MethodSource
         include ReeSourceLocation
 
       elsif defined?(RUBY_ENGINE) && RUBY_ENGINE =~ /jruby/
-        require 'jruby'
-
-        # JRuby version source_location hack
-        # @return [Array] A two element array containing the source location of the method
-        def source_location
-          to_java.source_location(JRuby.runtime.current_context)
-        end
+        # noop - source_location provided natively
       else
-
 
         def trace_func(event, file, line, id, binding, classname)
           return unless event == 'call'
@@ -83,16 +76,8 @@ module MethodSource
         include ReeSourceLocation
 
       elsif defined?(RUBY_ENGINE) && RUBY_ENGINE =~ /jruby/
-        require 'jruby'
-
-        # JRuby version source_location hack
-        # @return [Array] A two element array containing the source location of the method
-        def source_location
-          to_java.source_location(JRuby.runtime.current_context)
-        end
-
+        # noop - source_location provided natively
       else
-
 
         # Return the source location of an instance method for Ruby 1.8.
         # @return [Array] A two element array. First element is the

--- a/lib/method_source/source_location.rb
+++ b/lib/method_source/source_location.rb
@@ -13,12 +13,12 @@ module MethodSource
         include ReeSourceLocation
 
       elsif defined?(RUBY_ENGINE) && RUBY_ENGINE =~ /jruby/
-        require 'java'
+        require 'jruby'
 
         # JRuby version source_location hack
         # @return [Array] A two element array containing the source location of the method
         def source_location
-          to_java.source_location(Thread.current.to_java.getContext())
+          to_java.source_location(JRuby.runtime.current_context)
         end
       else
 
@@ -83,12 +83,12 @@ module MethodSource
         include ReeSourceLocation
 
       elsif defined?(RUBY_ENGINE) && RUBY_ENGINE =~ /jruby/
-        require 'java'
+        require 'jruby'
 
         # JRuby version source_location hack
         # @return [Array] A two element array containing the source location of the method
         def source_location
-          to_java.source_location(Thread.current.to_java.getContext())
+          to_java.source_location(JRuby.runtime.current_context)
         end
 
       else


### PR DESCRIPTION
the first commit replaces the internals with another piece (which is future proof on JRuby)

the seconds removes the hacks to just rely on what `source_location` already provides 
(the only downside I can think of is that this would break 1.8 mode for *long dead* JRuby 1.7.x)